### PR TITLE
Normalize DocumentBuilder field records

### DIFF
--- a/Classes/Builder/DocumentBuilder.php
+++ b/Classes/Builder/DocumentBuilder.php
@@ -264,24 +264,22 @@ class DocumentBuilder
                 continue;
             }
 
-            $fieldValue = $recordValue;
-
-            // Ignore empty field values
-            if ($fieldValue === null) {
+            // Only allow scalars or classes with __toString() method.
+            if (!is_scalar($recordValue) && !($recordValue instanceof \Stringable)) {
                 continue;
             }
 
-            if ($fieldValue === '') {
-                continue;
-            }
+            // Force the value to a string for consistency. $recordValue should never be boolean.
+            $stringValue = (string) $recordValue;
 
-            if ($fieldValue === []) {
+            // Skip empty strings.
+            if ($stringValue === '') {
                 continue;
             }
 
             $this->document->setField(
                 $fieldMapping[$recordFieldName],
-                ContentExtractor::cleanHtml($fieldValue)
+                ContentExtractor::cleanHtml($stringValue)
             );
         }
     }

--- a/Classes/Builder/DocumentBuilder.php
+++ b/Classes/Builder/DocumentBuilder.php
@@ -264,8 +264,8 @@ class DocumentBuilder
                 continue;
             }
 
-            // Only allow scalars or classes with __toString() method.
-            if (!is_scalar($recordValue) && !($recordValue instanceof \Stringable)) {
+            // Only allow scalars.
+            if (!is_scalar($recordValue)) {
                 continue;
             }
 


### PR DESCRIPTION
Fixes the use case where an integer is passed to the builder (e.g. doktype).
```
Typo3SearchAlgolia\ContentExtractor::cleanHtml(): Argument #1 ($content) must be of type string
```