### PR TITLE
WEB-1366: Add workspace handling

### DIFF
--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -32,7 +32,7 @@ return (new PhpCsFixer\Config())
     ->setUnsupportedPhpVersionAllowed(true)
     ->setRules([
         '@PSR12'                          => true,
-        '@PER-CS2.0'                      => true,
+        '@PER-CS2x0'                      => true,
         '@Symfony'                        => true,
 
         // Additional custom rules
@@ -48,6 +48,7 @@ return (new PhpCsFixer\Config())
         ],
         'phpdoc_to_comment'               => false,
         'phpdoc_no_alias_tag'             => false,
+        'phpdoc_annotation_without_dot'   => false,
         'no_superfluous_phpdoc_tags'      => false,
         'phpdoc_separation'               => [
             'groups' => [

--- a/Build/fractor.php
+++ b/Build/fractor.php
@@ -23,6 +23,6 @@ return FractorConfiguration::configure()
     )
     ->withSets(
         [
-            Typo3LevelSetList::UP_TO_TYPO3_13,
+            Typo3LevelSetList::UP_TO_TYPO3_12,
         ]
     );

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1,14 +1,24 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#2 \\$indexer of class MeineKrankenkasse\\\\Typo3SearchAlgolia\\\\Event\\\\AfterDocumentAssembledEvent constructor expects MeineKrankenkasse\\\\Typo3SearchAlgolia\\\\Service\\\\IndexerInterface, MeineKrankenkasse\\\\Typo3SearchAlgolia\\\\Service\\\\IndexerInterface\\|null given\\.$#"
-			count: 1
-			path: ../Classes/Builder/DocumentBuilder.php
-
-		-
 			message: """
 				#^Call to deprecated method setIgnoreEncryption\\(\\) of class Smalot\\\\PdfParser\\\\Config\\:
 				this is a temporary workaround, don't rely on it$#
 			"""
 			count: 1
 			path: ../Classes/EventListener/UpdateAssembledFileDocumentEventListener.php
+
+		-
+			message: "#^Call to method getRecordId\\(\\) on an unknown class TYPO3\\\\CMS\\\\Workspaces\\\\Event\\\\AfterRecordPublishedEvent\\.$#"
+			count: 1
+			path: ../Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
+
+		-
+			message: "#^Call to method getTable\\(\\) on an unknown class TYPO3\\\\CMS\\\\Workspaces\\\\Event\\\\AfterRecordPublishedEvent\\.$#"
+			count: 1
+			path: ../Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
+
+		-
+			message: "#^PHPDoc tag @var for variable \\$event contains unknown class TYPO3\\\\CMS\\\\Workspaces\\\\Event\\\\AfterRecordPublishedEvent\\.$#"
+			count: 1
+			path: ../Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php

--- a/Classes/Builder/DocumentBuilder.php
+++ b/Classes/Builder/DocumentBuilder.php
@@ -20,6 +20,8 @@ use MeineKrankenkasse\Typo3SearchAlgolia\Service\TypoScriptService;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
+use function is_scalar;
+
 /**
  * This class is responsible for transforming database records into document
  * objects that can be indexed by search engines. It handles:

--- a/Classes/Builder/DocumentBuilder.php
+++ b/Classes/Builder/DocumentBuilder.php
@@ -174,17 +174,19 @@ class DocumentBuilder
      */
     public function assemble(): DocumentBuilder
     {
-        if (!($this->indexer instanceof IndexerInterface)) {
+        $indexer = $this->indexer;
+
+        if (!($indexer instanceof IndexerInterface)) {
             return $this;
         }
 
         $this->document = GeneralUtility::makeInstance(
             Document::class,
-            $this->indexer,
+            $indexer,
             $this->record
         );
 
-        $tableName = $this->indexer->getTable();
+        $tableName = $indexer->getTable();
 
         // Set common fields
         $this->document
@@ -224,7 +226,7 @@ class DocumentBuilder
             ->dispatch(
                 new AfterDocumentAssembledEvent(
                     $this->document,
-                    $this->indexer,
+                    $indexer,
                     $this->indexingService,
                     $this->record
                 )

--- a/Classes/Controller/EnqueueOneController.php
+++ b/Classes/Controller/EnqueueOneController.php
@@ -35,7 +35,7 @@ use function is_array;
  * @license Netresearch https://www.netresearch.de
  * @link    https://www.netresearch.de
  */
-class EnqueueOneController
+readonly class EnqueueOneController
 {
     /**
      * Event dispatcher for triggering indexing events.
@@ -45,7 +45,7 @@ class EnqueueOneController
      *
      * @var EventDispatcherInterface
      */
-    private readonly EventDispatcherInterface $eventDispatcher;
+    private EventDispatcherInterface $eventDispatcher;
 
     /**
      * Factory for creating module template instances.
@@ -55,7 +55,7 @@ class EnqueueOneController
      *
      * @var ModuleTemplateFactory
      */
-    private readonly ModuleTemplateFactory $moduleTemplateFactory;
+    private ModuleTemplateFactory $moduleTemplateFactory;
 
     /**
      * Factory for retrieving file objects.
@@ -65,7 +65,7 @@ class EnqueueOneController
      *
      * @var ResourceFactory
      */
-    private readonly ResourceFactory $resourceFactory;
+    private ResourceFactory $resourceFactory;
 
     /**
      * Factory for creating HTTP responses.
@@ -75,7 +75,7 @@ class EnqueueOneController
      *
      * @var ResponseFactory
      */
-    private readonly ResponseFactory $responseFactory;
+    private ResponseFactory $responseFactory;
 
     /**
      * Handler for file-specific operations.
@@ -85,7 +85,7 @@ class EnqueueOneController
      *
      * @var FileHandler
      */
-    private readonly FileHandler $fileHandler;
+    private FileHandler $fileHandler;
 
     /**
      * Constructor.

--- a/Classes/EventListener/UpdateAssembledFileDocumentEventListener.php
+++ b/Classes/EventListener/UpdateAssembledFileDocumentEventListener.php
@@ -216,6 +216,7 @@ class UpdateAssembledFileDocumentEventListener
 
         // Prevent "json_encode error: Malformed UTF-8 characters, possibly incorrectly encoded"
         if (mb_detect_encoding($content) !== false) {
+            /** @var string|false $content */
             $content = mb_convert_encoding(
                 $content,
                 mb_detect_encoding($content),

--- a/Classes/EventListener/UpdateAssembledFileDocumentEventListener.php
+++ b/Classes/EventListener/UpdateAssembledFileDocumentEventListener.php
@@ -45,7 +45,7 @@ use TYPO3\CMS\Core\Resource\FileRepository;
  * @license Netresearch https://www.netresearch.de
  * @link    https://www.netresearch.de
  */
-class UpdateAssembledFileDocumentEventListener
+readonly class UpdateAssembledFileDocumentEventListener
 {
     /**
      * TYPO3 file repository for retrieving file objects.
@@ -58,7 +58,7 @@ class UpdateAssembledFileDocumentEventListener
      *
      * @var FileRepository
      */
-    private readonly FileRepository $fileRepository;
+    private FileRepository $fileRepository;
 
     /**
      * Initializes the event listener with the file repository service.

--- a/Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
+++ b/Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
@@ -33,7 +33,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  * @license Netresearch https://www.netresearch.de
  * @link    https://www.netresearch.de
  */
-class AfterRecordPublishedEventListener
+readonly class AfterRecordPublishedEventListener
 {
     /**
      * Event dispatcher for triggering search-related events.
@@ -45,7 +45,7 @@ class AfterRecordPublishedEventListener
      *
      * @var EventDispatcherInterface
      */
-    protected readonly EventDispatcherInterface $eventDispatcher;
+    protected EventDispatcherInterface $eventDispatcher;
 
     /**
      * Constructor method for initializing the class.

--- a/Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
+++ b/Classes/EventListener/Workspace/AfterRecordPublishedEventListener.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * This file is part of the package meine-krankenkasse/typo3-search-algolia.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MeineKrankenkasse\Typo3SearchAlgolia\EventListener\Workspace;
+
+use MeineKrankenkasse\Typo3SearchAlgolia\Event\DataHandlerRecordUpdateEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * Listener that handles operations after a record is published.
+ *
+ * This class listens to the `AfterRecordPublishedEvent` and utilizes an
+ * event dispatcher to trigger related search engine events, ensuring
+ * synchronization between published data and search metadata. It primarily
+ * manages the dispatching of `DataHandlerRecordUpdateEvent` to keep the
+ * search index up-to-date with changes in the record data.
+ *
+ * Note: This listener requires typo3/cms-workspaces to be installed.
+ * The event parameter is not type-hinted to allow the extension to work
+ * without the workspaces extension installed. If workspaces is not loaded,
+ * the listener will return early without doing anything.
+ *
+ * @author  Rico Sonntag <rico.sonntag@netresearch.de>
+ * @license Netresearch https://www.netresearch.de
+ * @link    https://www.netresearch.de
+ */
+class AfterRecordPublishedEventListener
+{
+    /**
+     * Event dispatcher for triggering search-related events.
+     *
+     * This property stores the event dispatcher service that is used by concrete
+     * implementations to dispatch DataHandler events (like DataHandlerRecordUpdateEvent
+     * or DataHandlerRecordDeleteEvent) when file operations occur. These events
+     * ensure that file metadata is properly indexed or removed from the search engine.
+     *
+     * @var EventDispatcherInterface
+     */
+    protected readonly EventDispatcherInterface $eventDispatcher;
+
+    /**
+     * Constructor method for initializing the class.
+     *
+     * @param EventDispatcherInterface $eventDispatcher An instance of EventDispatcherInterface for event handling
+     *
+     * @return void
+     */
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    /**
+     * Invokes the object as a function to handle the event.
+     *
+     * Note: The $event parameter is not type-hinted with AfterRecordPublishedEvent
+     * to allow this extension to work without typo3/cms-workspaces installed.
+     * The event will only be dispatched when workspaces extension is active.
+     *
+     * This method will return early if:
+     * - The workspaces extension is not loaded
+     * - The event object doesn't have the expected methods
+     *
+     * @param object $event The event instance containing information about the published record.
+     *                      Expected to be TYPO3\CMS\Workspaces\Event\AfterRecordPublishedEvent when workspaces is installed.
+     *
+     * @return void
+     */
+    public function __invoke(object $event): void
+    {
+        // Early return if workspaces extension is not loaded
+        if (!ExtensionManagementUtility::isLoaded('workspaces')) {
+            return;
+        }
+
+        // Verify that the event has the expected methods
+        if (
+            !method_exists($event, 'getTable')
+            || !method_exists($event, 'getRecordId')
+        ) {
+            return;
+        }
+
+        // The event is guaranteed to be AfterRecordPublishedEvent at runtime
+        /** @var \TYPO3\CMS\Workspaces\Event\AfterRecordPublishedEvent $event */
+        $this->eventDispatcher
+            ->dispatch(
+                new DataHandlerRecordUpdateEvent($event->getTable(), $event->getRecordId())
+            );
+    }
+}

--- a/Classes/Repository/CategoryRepository.php
+++ b/Classes/Repository/CategoryRepository.php
@@ -55,7 +55,7 @@ readonly class CategoryRepository
      * @param string $tableName
      * @param int    $uid
      *
-     * @return array<array-key, string>
+     * @return array<array-key, array<string, int|string|null>>
      *
      * @throws Exception
      */

--- a/Classes/Repository/PageRepository.php
+++ b/Classes/Repository/PageRepository.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace MeineKrankenkasse\Typo3SearchAlgolia\Repository;
 
 use Doctrine\DBAL\Exception;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
@@ -62,6 +63,35 @@ readonly class PageRepository
     public function __construct(ConnectionPool $connectionPool)
     {
         $this->connectionPool = $connectionPool;
+    }
+
+    /**
+     * Retrieves a database record for a given table and record UID.
+     *
+     * This method fetches the data for a specific record from the specified table.
+     * It allows selecting specific fields, applying a delete clause, and ensures
+     * that the retrieved data is returned as an array.
+     *
+     * @param string $tableName       The name of the database table to fetch the record from
+     * @param int    $recordUid       The UID of the record to retrieve
+     * @param string $fields          The fields to select in the query, defaults to '*'
+     * @param bool   $useDeleteClause Whether to include a clause for filtering deleted records, defaults to true
+     *
+     * @return array<string, int|string|null> An associative array containing the record data, or an empty array if the record is not found
+     */
+    public function getPageRecord(
+        string $tableName,
+        int $recordUid,
+        string $fields = '*',
+        bool $useDeleteClause = true,
+    ): array {
+        return BackendUtility::getRecord(
+            $tableName,
+            $recordUid,
+            $fields,
+            '',
+            $useDeleteClause
+        ) ?? [];
     }
 
     /**

--- a/Classes/Repository/RecordRepository.php
+++ b/Classes/Repository/RecordRepository.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  * @license Netresearch https://www.netresearch.de
  * @link    https://www.netresearch.de
  */
-class RecordRepository
+readonly class RecordRepository
 {
     /**
      * TYPO3 database connection pool for direct database operations.
@@ -42,7 +42,7 @@ class RecordRepository
      *
      * @var ConnectionPool
      */
-    private readonly ConnectionPool $connectionPool;
+    private ConnectionPool $connectionPool;
 
     /**
      * Initializes the repository with the database connection pool.

--- a/Classes/Service/Indexer/AbstractIndexer.php
+++ b/Classes/Service/Indexer/AbstractIndexer.php
@@ -520,7 +520,8 @@ abstract class AbstractIndexer implements IndexerInterface
         $queryBuilder->getRestrictions()
             ->removeAll()
             ->add(GeneralUtility::makeInstance(DefaultRestrictionContainer::class))
-            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class));
+            ->add(GeneralUtility::makeInstance(WorkspaceRestriction::class))
+        ;
 
         // Get the field statement for determining when a record was last changed
         $changedFieldStatement = $this->getChangedFieldStatement();

--- a/Classes/Service/Indexer/ContentIndexer.php
+++ b/Classes/Service/Indexer/ContentIndexer.php
@@ -72,7 +72,7 @@ class ContentIndexer extends AbstractIndexer
     #[Override]
     protected function getAdditionalQueryConstraints(QueryBuilder $queryBuilder): array
     {
-        $constraints = [];
+        $constraints = parent::getAdditionalQueryConstraints($queryBuilder);
 
         // Get content element types from indexing service configuration
         $contentElementTypes = GeneralUtility::trimExplode(

--- a/Classes/Service/Indexer/FileIndexer.php
+++ b/Classes/Service/Indexer/FileIndexer.php
@@ -167,12 +167,12 @@ class FileIndexer extends AbstractIndexer
      * it retrieves files from file collections, filters them by extension and
      * indexability, and prepares them for indexing.
      *
-     * @param int[] $pageIds Unused parameter, kept for compatibility with parent method
+     * @param int[] $recordUids Unused parameter, kept for compatibility with parent method
      *
      * @return array<array-key, array<string, int|string>> Array of prepared file records
      */
     #[Override]
-    protected function initQueueItemRecords(array $pageIds = []): array
+    protected function initQueueItemRecords(array $recordUids = []): array
     {
         $collectionIds = GeneralUtility::intExplode(
             ',',

--- a/Classes/Service/Indexer/PageIndexer.php
+++ b/Classes/Service/Indexer/PageIndexer.php
@@ -91,13 +91,16 @@ class PageIndexer extends AbstractIndexer
     #[Override]
     protected function getAdditionalQueryConstraints(QueryBuilder $queryBuilder): array
     {
-        $constraints = [
-            // Include only pages which are not explicitly excluded from search
-            $queryBuilder->expr()->eq(
-                'no_search',
-                0
-            ),
-        ];
+        $constraints = array_merge(
+            parent::getAdditionalQueryConstraints($queryBuilder),
+            [
+                // Include only pages which are not explicitly excluded from search
+                $queryBuilder->expr()->eq(
+                    'no_search',
+                    0
+                ),
+            ]
+        );
 
         // Get page types from indexing service configuration
         $pageTypes = GeneralUtility::intExplode(

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -106,3 +106,10 @@ services:
             -   name: event.listener
                 identifier: 'typo3-search-algolia/resource-after-file-replaced-event-listener'
                 event: TYPO3\CMS\Core\Resource\Event\AfterFileReplacedEvent
+
+    # Workspace event listeners (optional - requires typo3/cms-workspaces)
+    MeineKrankenkasse\Typo3SearchAlgolia\EventListener\Workspace\AfterRecordPublishedEventListener:
+        tags:
+            -   name: event.listener
+                identifier: 'typo3-search-algolia/workspace-after-record-published-event-listener'
+                event: TYPO3\CMS\Workspaces\Event\AfterRecordPublishedEvent

--- a/README.md
+++ b/README.md
@@ -40,3 +40,14 @@ relevant search results.
   - [Content Element Indexer](Documentation/ContentElementIndexer.md)
   - [News Indexer](Documentation/NewsIndexer.md)
   - [File Indexer](Documentation/FileIndexer.md)
+
+## Optional Features
+
+### Workspace Support
+To enable automatic reindexing when publishing workspace records, install the workspaces extension:
+
+```bash
+composer require typo3/cms-workspaces
+```
+
+Without this extension, the search indexer will still work but won't automatically queue records when publishing from workspaces.

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,9 @@
         "ssch/typo3-rector": "^2.0",
         "a9f/typo3-fractor": "^0.5"
     },
+    "suggest": {
+        "typo3/cms-workspaces": "Required for workspace support and automatic reindexing when publishing workspace records"
+    },
     "config": {
         "bin-dir": ".build/bin",
         "vendor-dir": ".build/vendor",


### PR DESCRIPTION
# UAT: Workspace Support for Algolia Indexing (WEB-1366)

## Summary
The Algolia extension now automatically indexes all changes published to LIVE from the "Editorial" workspace.

## What has changed?


# UAT: Workspace Support for Algolia Indexing (WEB-1366)

## Summary
The Algolia extension now automatically indexes all changes published to LIVE from the "Editorial" workspace.

## What has changed? ... ### New Functionality
- **Workspace Publish Integration**: When publishing changes from the "Editorial" workspace, affected pages and content are automatically added to the Algolia indexing queue.

- **Draft Filtering**: Changes made in workspace mode are processed only after publishing, not during editing.

- **Recursive Update**: When publishing pages, all subpages and content elements are automatically included.

### Technical Details

- Event listener for `AfterRecordPublishedEvent` (TYPO3 workspaces)

- Enhanced `DataHandlerHook` with workspace awareness

- Optional: Extension also works without `typo3/cms-workspaces` installed.

---

## User Acceptance Test (UAT)

### Prerequisites
- Access to the TYPO3 backend with the "Editorial" workspace

- Permission to publish workspace changes

- Scheduler task for Algolia indexing is Active

### Test Scenarios

#### ✅ Test 1: Create and publish a new page in the workspace

**Steps:**

1. Switch to the "Editorial" workspace in the backend

2. Create a new page (e.g., "Test page for Algolia")

3. Fill the page with content (heading, text, etc.)

4. Save
5. Switch to the "Workspace" module → "Publish Workspace"
6. Publish the changes to LIVE

**Expected result:**
- After publishing, the new page appears in the index queue (Backend → Algolia Search → Queue)
- After the scheduler task is executed, the page is searchable in Algolia
- Frontend search finds the new page

---

#### ✅ Test 2: Edit an existing page in the workspace

**Steps:**

1. Edit an existing page in the "Editorial" workspace

2. Change the title or content
3. Save (changes remain in the workspace)
4. Check: Algolia queue should NOT be updated
5. Publish changes after going live

**Expected result:**

- During editing: No queue entries
- After publishing: Page appears in the queue

- After scheduler run: Updated content in Algolia

---

#### ✅ Test 3: Adding a content element to the workspace

**Steps:**

1. In the "Editorial" workspace, add a new content element to a page

2. Save

3. Publish

**Expected result:**

- After publishing: Both the page and the content element are added to the queue

- The Algolia index contains the new content element after the scheduler run

---

#### ✅ Test 4: Deleting a page in the workspace

**Steps:**

1. In the "Editorial" workspace, delete a page

2. Publish

**Expected Result:**

- Page is removed from the Algolia index
- Frontend search no longer finds the page

---

#### ✅ Test 5: Publish multiple changes simultaneously

**Steps:**

1. In the "Editorial" workspace:

- Create 2 new pages

- Edit 1 existing page

- Add 3 content elements
2. Publish all changes at once

**Expected Result:**

- All affected pages and content elements are added to the queue
- After the scheduler runs, all changes are visible in Algolia

---

#### ✅ Test 6: Publish a page with subpages

**Steps:**

1. In the "Editorial" workspace, edit a page with 2-3 subpages

2. Publish

**Expected Result:**

- Parent page and all subpages are added to the queue

- Recursive update of the entire page Page Trees

---

### Queue Check

**Backend → Algolia Search → Queue:**

- List shows all published records

- Status: "Pending"

- After Scheduler Run: Status "Indexed"

**Backend → System → Scheduler:**

- Task "Algolia: Index Queue Worker" successfully executed

- Log shows processed items

---

## Known Limitations

1. **Scheduler-dependent**: Changes only appear in Algolia after the Scheduler task has run (not immediately after publishing)

2. **Large batches**: Queue processing can take longer with a very large number of simultaneous publishes

3. **Draft Records**: Changes in the workspace are intentionally NOT visible in Algolia until published